### PR TITLE
The `System.Drawing.Common` before 4.7.2 is vulnerable

### DIFF
--- a/src/Spring.Extensions.DependencyInjection/Spring.Extensions.DependencyInjection.csproj
+++ b/src/Spring.Extensions.DependencyInjection/Spring.Extensions.DependencyInjection.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- https://github.com/advisories/GHSA-rxg9-xrhp-64gj